### PR TITLE
Fix a crash in floating_counter

### DIFF
--- a/hatenabookmark.safariextension/background/floating_counter.js
+++ b/hatenabookmark.safariextension/background/floating_counter.js
@@ -20,7 +20,7 @@
 
     function show(entry) {
         $(function() {
-            if (!Config.get("content.fans.enabled")) {
+            if (!Config.get("content.fans.enabled") || !Array.isArray(entry.favorites)) {
                 hideWindow();
                 return;
             }


### PR DESCRIPTION
未ログイン時に entry.favorites が取得できないために発生しているJavaScriptエラーを修正します。
